### PR TITLE
fix: 修复快速反向滚动时回调冲突问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g-gesture",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Gesture module for @antv/g.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/src/event/wheel.ts
+++ b/src/event/wheel.ts
@@ -56,6 +56,12 @@ export class Wheel extends EE implements Event {
    * @param ev
    */
   private onPan = (ev: GestureEvent) => {
+
+    // pan 时取消掉 swipe 的延时回调
+    if(this.raf){
+      cancelAnimationFrame(this.raf)
+    }
+
     const { deltaX, deltaY } = ev;
 
     const e = this.getWrapperEvent(ev, deltaX, deltaY);


### PR DESCRIPTION
在当前滚动还未停止时，马上向反方向滚动，会出现滚动错乱的问题，因为swipe的延时回调没有取消，导致和新的滚动冲突

|Before| After|
| ---- | ---- |
|![2022-02-08 19 30 46](https://user-images.githubusercontent.com/17964556/152980379-b78b42e8-38e9-443f-a93b-b06666544c4e.gif)|![2022-02-08 19 29 13](https://user-images.githubusercontent.com/17964556/152980437-bc62788c-5dba-4f64-a883-e11e4c0f7dd3.gif)|

 